### PR TITLE
Updated appendToTag function

### DIFF
--- a/compiler/src/main/java/se/lth/cs/tycho/phase/ActionGeneratorEnumeration.java
+++ b/compiler/src/main/java/se/lth/cs/tycho/phase/ActionGeneratorEnumeration.java
@@ -327,8 +327,9 @@ public class ActionGeneratorEnumeration implements Phase {
          * @return The updated tag.
          */
         default QID appendToTag(QID qid, String suffix) {
-            String last = qid.getLast().toString() + suffix;
-            return qid.withLast(last);
+            //String last = qid.getLast().toString() + suffix;
+            QID last = QID.parse(suffix);
+            return qid.concat(last);
         }
 
         /**


### PR DESCRIPTION
When using the foreach statement to generate  actions, each actionTag now has the action number appended to the tag instead of creating a whole new tag.

For example
'''
foreach uint i in 0..1 generate
    actionTag: action In[i]:[token] ==>  Out[i]:[token + i] end
end
'''

Now becomes:
'''
actionTag._0: action In[0]:[token] ==>  Out[0]:[token + 0] end
actionTag._1: action In[1]:[token] ==> Out[1]:[token + 1] end
'''

previously it became:
'''
actionTag_0: action In[0]:[token] ==>  Out[0]:[token + 0] end // No longer works this way
actionTag_1: action In[1]:[token] ==> Out[1]:[token + 1] end // No longer works this way
'''